### PR TITLE
[PHP 8.5] Use `PHP_BUILD_DATE` constant

### DIFF
--- a/src/Debug/Utility/Php.php
+++ b/src/Debug/Utility/Php.php
@@ -36,6 +36,10 @@ class Php
      */
     public function buildDate()
     {
+        if (\defined('PHP_BUILD_DATE')) {
+            return PHP_BUILD_DATE;
+        }
+
         \ob_start();
         \phpinfo(INFO_GENERAL);
         $phpInfo = \ob_get_clean();


### PR DESCRIPTION
PHP 8.5 has a [new constant named `PHP_BUILD_DATE`](https://php.watch/versions/8.5/PHP_BUILD_DATE) that contains the same value as the `phpinfo` build date.

We currently use "Build date" field parsed from `phpinfo` output, but on PHP 8.5, we can simply return the `PHP_BUILD_DATE` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `buildDate` method to return the PHP build date directly if available, improving efficiency.

- **Bug Fixes**
	- Addressed potential issues with parsing the output of `phpinfo()` by introducing a new conditional check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->